### PR TITLE
feat(collection): Makes collection extensible

### DIFF
--- a/addon-test-support/-private/utils/deep-merge-descriptors.js
+++ b/addon-test-support/-private/utils/deep-merge-descriptors.js
@@ -1,0 +1,24 @@
+export default function deepMergeDescriptors(dest, src) {
+  Object.getOwnPropertyNames(src).forEach((name) => {
+    // Copy descriptor
+    let descriptor = Object.getOwnPropertyDescriptor(src, name)
+
+    if (Object.hasOwnProperty.call(dest, name)) {
+      const { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
+      const { value: srcValue } = descriptor;
+
+      if (
+        typeof destValue === 'object' && destValue !== null
+        && typeof srcValue === 'object' && srcValue !== null
+      ) {
+        descriptor.value = deepMergeDescriptors(destValue, srcValue);
+      } else {
+        return;
+      }
+    }
+
+    Object.defineProperty(dest, name, descriptor)
+  });
+
+  return dest;
+}

--- a/addon-test-support/-private/utils/walk.js
+++ b/addon-test-support/-private/utils/walk.js
@@ -1,0 +1,16 @@
+export default function walk(object, ...cbs) {
+  Object.getOwnPropertyNames(object).forEach((name) => {
+    // Extract descriptors so we don't trigger getters or setters
+    const descriptor = Object.getOwnPropertyDescriptor(object, name);
+
+    for (let i = 0; i < cbs.length; i++) {
+      cbs[i](object, name, descriptor);
+    }
+
+    if (typeof descriptor.value === 'object' && descriptor.value !== null) {
+      walk(descriptor.value, ...cbs);
+    }
+  });
+
+  return object;
+}

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,63 +1,23 @@
-import { create } from 'ember-cli-page-object';
+export {
+  attribute,
+  clickOnText,
+  clickable,
+  contains,
+  count,
+  fillable,
+  hasClass,
+  is,
+  isHidden,
+  isPresent,
+  isVisible,
+  notHasClass,
+  property,
+  text,
+  triggerable,
+  value,
+  visitable
+} from 'ember-cli-page-object';
 
-function deepMergeDescriptors(dest, src) {
-  Object.getOwnPropertyNames(src).forEach(function forEachOwnPropertyName(name) {
-    // Copy descriptor
-    let descriptor = Object.getOwnPropertyDescriptor(src, name)
+export { collection } from './properties/collection';
 
-    if (Object.hasOwnProperty.call(dest, name)) {
-      const { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
-      const { value: srcValue } = descriptor;
-
-      if (
-        typeof destValue === 'object' && destValue !== null
-        && typeof srcValue === 'object' && srcValue !== null
-      ) {
-        descriptor.value = deepMergeDescriptors(destValue, srcValue);
-      } else {
-        return;
-      }
-    }
-
-    Object.defineProperty(dest, name, descriptor)
-  });
-
-  return dest;
-}
-
-function replaceDescriptors(object) {
-  Object.getOwnPropertyNames(object).forEach((name) => {
-    // Extract descriptors for getters/setters
-    let descriptor = Object.getOwnPropertyDescriptor(object, name);
-
-    if (descriptor.get || descriptor.set) {
-      const { get, set } = descriptor;
-
-      delete object[name];
-
-      object[name] = {
-        isDescriptor: true,
-        get,
-        set
-      };
-    } else if (typeof descriptor.value === 'object' && descriptor.value !== null) {
-      replaceDescriptors(descriptor.value);
-    }
-  });
-
-  return object;
-}
-
-export class PageObject {
-  constructor(definition) {
-    Object.assign(this, replaceDescriptors(definition));
-  }
-
-  extend(extension) {
-    return new PageObject(deepMergeDescriptors(extension, this))
-  }
-
-  create() {
-    return create(this);
-  }
-}
+export { default } from './page-object';

--- a/addon-test-support/page-object.js
+++ b/addon-test-support/page-object.js
@@ -1,0 +1,50 @@
+import { create, collection } from 'ember-cli-page-object';
+import deepMergeDescriptors from './-private/utils/deep-merge-descriptors';
+import walk from './-private/utils/walk';
+
+import { useNativeEvents } from 'ember-cli-page-object/extend';
+
+// pre-emptively turn on native events since we'll need them
+useNativeEvents();
+
+// Turns a native getter into a Ceibo getter
+function replaceDescriptors(object, property, descriptor) {
+  const { get, set } = descriptor;
+
+  if (!get && !set) return;
+
+  delete object[property];
+
+  object[property] = {
+    isDescriptor: true,
+    get,
+    set
+  };
+}
+
+// Turns an extendible collection placeholder into an ember-cli-page-object collection
+function replaceCollections(object, property, descriptor) {
+  const { value } = descriptor;
+
+  if (!value || !value.isCollection) return;
+
+  delete value.isCollection;
+
+  object[property] = collection(value);
+}
+
+export default class PageObject {
+  constructor(definition) {
+    definition = walk(definition, replaceDescriptors);
+
+    Object.assign(this, definition);
+  }
+
+  extend(extension) {
+    return new PageObject(deepMergeDescriptors(extension, this))
+  }
+
+  create() {
+    return create(walk(this, replaceCollections));
+  }
+}

--- a/addon-test-support/properties/collection.js
+++ b/addon-test-support/properties/collection.js
@@ -1,0 +1,7 @@
+export function collection(definition) {
+  const collectionDefinition = { isCollection: true };
+
+  Object.assign(collectionDefinition, definition);
+
+  return collectionDefinition;
+}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   treeForAddonTestSupport(tree) {
     // intentionally not calling _super here
     // so that can have our `import`'s be
-    // import { PageObject, ScopedPageObject } from 'ember-classy-page-object';
+    // import { PageObject } from 'ember-classy-page-object';
 
     const Funnel = require('broccoli-funnel');
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-page-object": "pzuraq/ember-cli-page-object#af35424"
+    "ember-cli-page-object": "pzuraq/ember-cli-page-object#fdadc85aed468a2aeeb88ade5e2a9b4dc4a8b54d"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -1,4 +1,4 @@
-import { PageObject } from 'ember-classy-page-object';
+import PageObject from 'ember-classy-page-object';
 
 import { module, test } from 'ember-qunit';
 

--- a/tests/unit/properties-test.js
+++ b/tests/unit/properties-test.js
@@ -1,0 +1,44 @@
+import PageObject, { collection } from 'ember-classy-page-object';
+
+import { module, test } from 'ember-qunit';
+
+module('basic tests');
+
+test('it properly merges collections', function(assert) {
+  assert.expect(4);
+
+  let page = new PageObject({
+    foo: 123,
+    content: collection({
+      bar: 456
+    })
+  }).extend({
+    content: {
+      baz: 789
+    }
+  });
+
+  assert.equal(page.foo, 123);
+  assert.ok(page.content.isCollection);
+  assert.equal(page.content.bar, 456);
+  assert.equal(page.content.baz, 789);
+});
+
+test('it properly replaces collections', function(assert) {
+  assert.expect(1);
+
+  let page = new PageObject({
+    foo: 123,
+    content: collection({
+      bar: 456
+    })
+  }).extend({
+    content: {
+      baz: 789
+    }
+  }).create();
+
+  let collectionDescriptor = Object.getOwnPropertyDescriptor(page, 'content');
+
+  assert.equal(typeof collectionDescriptor.get, 'function', 'correctly replaced with collection');
+});


### PR DESCRIPTION
Also refactors the external API and re-exports ember-cli-page-object helpers so we can control them in the future, if needed