### PR TITLE
refactor(major): Normalize PageObject API, re-export all helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,119 @@
 # ember-classy-page-object
 
-This README outlines the details of collaborating on this Ember addon.
+Provides a super simple class-like wrapper around ember-cli-page-object.
+
+## Usage
+
+Given a simple ToggleButton component that just toggles it's is active state with a
+template like so:
+
+```hbs
+<!-- note activeClass defaults to `is-active` -->
+<button {{action "toggleActive"}} data-test-toggle-button class="{{if active activeClass}}">
+  {{if active "Deactivate" "Activate"}}
+</button>
+```
+
+You can represent it and test like this:
+
+```js
+import { module, test } from 'ember-qunit';
+
+import PageObject, { clickable } from 'ember-classy-page-object';
+import { findElement } from 'ember-classy-page-object/extend';
+
+const ToggleButtonPage = PageObject.extend({
+  toggle: clickable('[data-test-toggle-button]'),
+
+  activeClass: 'is-active',
+
+  get isActive() {
+    return findElement(this, '[data-test-toggle-button]').classList.contains(this.activeClass);
+  }
+});
+
+module('toggle button');
+
+test('can toggle', function(assert) {
+	const myToggleButton = ToggleButtonPage.create();
+
+	myToggleButton.toggle();
+
+	assert.ok(myToggleButton.isActive, 'it toggled!');
+});
+```
+
+If you later need to reuse a component, you can extend it to override properties:
+
+```hbs
+{{toggle-button data-test-first-toggle=true}}
+{{toggle-button data-test-second-toggle=true activeClass="is-activated"}}
+```
+
+```js
+const DoubleToggleButtonPage = PageObject.extend({
+  firstToggle: ToggleButtonPage.extend({
+	  scope: '[data-test-first-toggle]'
+  }),
+
+  secondToggle: ToggleButtonPage.extend({
+	  scope: '[data-test-second-toggle]',
+	  activeClass: 'is-activated'
+  })
+});
+
+const myDoubleToggle = DoubleToggleButtonPage.create();
+
+myDoubleToggle.firstToggle.toggle();
+// etc...
+```
+
+Extending deep merges the new definition into the previous definition. When you want to finally
+use the page object, just call `create` which finalizes the object.
+
+## Jquery vs Native
+
+Classy page object defaults to running in native-dom mode, meaning it sends native events and
+uses native-dom helpers under the hood. Results from functions like `findElement` and
+`findElementWithAssert` return actual elements, not jquery selectors. However, ember-cli-page-object
+hasn't been able to get rid of the jquery dependency yet, so it's still possible to use jquery
+selectors within page objects themselves. It is _highly_ recommended that you avoid this to prevent
+tying yourself to jquery in your tests, as Ember continues to remove the dependency in the future.
+
+## Helpers
+
+Classy page object re-exports all of the helpers from ember-cli-page-object with the exception of
+`getter`, you can now use native ES getters instead. The list of exports is as follows:
+
+* `ember-classy-page-object`
+  * `default as PageObject`
+  * `alias`
+  * `attribute`
+  * `clickOnText`
+  * `clickable`
+  * `contains`
+  * `count`
+  * `fillable`
+  * `hasClass`
+  * `is`
+  * `isHidden`
+  * `isPresent`
+  * `isVisible`
+  * `notHasClass`
+  * `property`
+  * `text`
+  * `triggerable`
+  * `value`
+  * `visitable`
+* `ember-classy-page-object/extend`
+  * `findElement`
+  * `findElementWithAssert`
+  * `buildSelector`
+  * `fullScope`
+  * `getContext`
+
+Some helpers like `collection` have been modified to make them extendible, so it is highly recommended
+that you import the helpers from classy page object instead of ember-cli-page-object.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides a super simple class-like wrapper around ember-cli-page-object.
 
 ## Usage
 
-Given a simple ToggleButton component that just toggles it's is active state with a
+Given a simple ToggleButton component that just toggles its active state with a
 template like so:
 
 ```hbs

--- a/addon-test-support/-private/page-object.js
+++ b/addon-test-support/-private/page-object.js
@@ -1,6 +1,8 @@
+import { assert } from '@ember/debug';
+
 import { create, collection } from 'ember-cli-page-object';
-import deepMergeDescriptors from './-private/utils/deep-merge-descriptors';
-import walk from './-private/utils/walk';
+import deepMergeDescriptors from './utils/deep-merge-descriptors';
+import walk from './utils/walk';
 
 import { useNativeEvents } from 'ember-cli-page-object/extend';
 
@@ -33,7 +35,7 @@ function replaceCollections(object, property, descriptor) {
   object[property] = collection(value);
 }
 
-export default class PageObject {
+class PageObject {
   constructor(definition) {
     definition = walk(definition, replaceDescriptors);
 
@@ -41,6 +43,8 @@ export default class PageObject {
   }
 
   extend(extension) {
+    assert('must provide a definition with atleast one key when extending a PageObject', extension && Object.keys(extension).length > 0);
+
     return new PageObject(deepMergeDescriptors(extension, this))
   }
 
@@ -48,3 +52,5 @@ export default class PageObject {
     return create(walk(this, replaceCollections));
   }
 }
+
+export default new PageObject({});

--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -1,7 +1,9 @@
+import deepMergeDescriptors from '../utils/deep-merge-descriptors';
+
 export function collection(definition) {
   const collectionDefinition = { isCollection: true };
 
-  Object.assign(collectionDefinition, definition);
+  deepMergeDescriptors(collectionDefinition, definition);
 
   return collectionDefinition;
 }

--- a/addon-test-support/extend.js
+++ b/addon-test-support/extend.js
@@ -1,0 +1,22 @@
+export {
+  buildSelector,
+  fullScope,
+  getContext
+} from 'ember-cli-page-object/extend';
+
+import {
+  findElement as originalFindElement,
+  findElementWithAssert as originalFindElementWithAssert
+} from 'ember-cli-page-object/extend';
+
+export function findElement(node, selector, options = {}) {
+  const result = originalFindElement(node, selector, options);
+
+  return options.multiple ? result.toArray() : result[0];
+}
+
+export function findElementWithAssert(node, selector, options = {}) {
+  const result = originalFindElementWithAssert(node, selector, options);
+
+  return options.multiple ? result.toArray() : result[0];
+}

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -18,6 +18,10 @@ export {
   visitable
 } from 'ember-cli-page-object';
 
-export { collection } from './properties/collection';
+export {
+  alias
+} from 'ember-cli-page-object/macros';
 
-export { default } from './page-object';
+export { collection } from './-private/properties/collection';
+
+export { default } from './-private/page-object';

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",
+    "ember-test-selectors": "^0.3.8",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -1,0 +1,48 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+import PageObject, { clickable } from 'ember-classy-page-object';
+import { findElement } from 'ember-classy-page-object/extend';
+
+const ToggleButtonPage = PageObject.extend({
+  toggle: clickable('[data-test-toggle-button]'),
+
+  activeClass: 'is-active',
+
+  get isActive() {
+    return findElement(this, '[data-test-toggle-button]').classList.contains(this.activeClass);
+  }
+});
+
+const DoubleTogglePage = PageObject.extend({
+  firstToggle: ToggleButtonPage.extend({
+    scope: '[data-test-first-toggle]'
+  }),
+
+  secondToggle: ToggleButtonPage.extend({
+    scope: '[data-test-second-toggle]',
+    activeClass: 'is-activated'
+  })
+});
+
+
+moduleForAcceptance('Acceptance | simple');
+
+test('visiting /', function(assert) {
+  const doubleToggle = DoubleTogglePage.create();
+
+  visit('/');
+
+  andThen(() => {
+    assert.equal(doubleToggle.firstToggle.isActive, false);
+    assert.equal(doubleToggle.secondToggle.isActive, false);
+  });
+
+  doubleToggle.firstToggle.toggle()
+  doubleToggle.secondToggle.toggle()
+
+  andThen(() => {
+    assert.equal(doubleToggle.firstToggle.isActive, true);
+    assert.equal(doubleToggle.secondToggle.isActive, true);
+  });
+});

--- a/tests/dummy/app/components/toggle-button.js
+++ b/tests/dummy/app/components/toggle-button.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  activeClass: 'is-active',
+
+  actions: {
+    toggleActive() {
+      this.toggleProperty('active');
+    }
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,1 @@
-<h2 id="title">Welcome to Ember</h2>
-
-{{outlet}}
+{{double-toggle-button}}

--- a/tests/dummy/app/templates/components/double-toggle-button.hbs
+++ b/tests/dummy/app/templates/components/double-toggle-button.hbs
@@ -1,0 +1,2 @@
+{{toggle-button data-test-first-toggle=true}}
+{{toggle-button data-test-second-toggle=true activeClass="is-activated"}}

--- a/tests/dummy/app/templates/components/toggle-button.hbs
+++ b/tests/dummy/app/templates/components/toggle-button.hbs
@@ -1,0 +1,3 @@
+<button {{action "toggleActive"}} data-test-toggle-button class="{{if active activeClass}}">
+  {{if active "Deactivate" "Activate"}}
+</button>

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -7,7 +7,7 @@ module('basic tests');
 test('it properly converts descriptors', function(assert) {
   assert.expect(3);
 
-  let page = new PageObject({
+  let page = PageObject.extend({
     get foo() {
       assert.ok(true, 'getter converted correctly');
     },
@@ -26,7 +26,7 @@ test('it properly converts descriptors', function(assert) {
 test('it properly merges subcontexts', function(assert) {
   assert.expect(4);
 
-  let page = new PageObject({
+  let page = PageObject.extend({
     foo: 123,
     content: {
       bar: 456

--- a/tests/unit/properties-test.js
+++ b/tests/unit/properties-test.js
@@ -7,7 +7,7 @@ module('basic tests');
 test('it properly merges collections', function(assert) {
   assert.expect(4);
 
-  let page = new PageObject({
+  let page = PageObject.extend({
     foo: 123,
     content: collection({
       bar: 456
@@ -27,7 +27,7 @@ test('it properly merges collections', function(assert) {
 test('it properly replaces collections', function(assert) {
   assert.expect(1);
 
-  let page = new PageObject({
+  let page = PageObject.extend({
     foo: 123,
     content: collection({
       bar: 456

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,7 +1242,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -1813,6 +1813,23 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.6.0, e
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
+ember-cli-babel@^6.8.2:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.9.0.tgz#5147391389bdbb7091d15f81ae1dff1eb49d71aa"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.0"
+
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.0.4.tgz#f43f42f75b7509c212fb926cd9aea86ae19264c6"
@@ -2200,6 +2217,14 @@ ember-source@~2.16.0:
 ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
+
+ember-test-selectors@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-0.3.8.tgz#1e8ae3e78c64bacc4bbfe87f9973c85805699db2"
+  dependencies:
+    broccoli-stew "^1.4.0"
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^2.0.0"
 
 ember-try-config@^2.0.1:
   version "2.1.0"


### PR DESCRIPTION
Normalizes the PageObject API to always use `extend` instead of `new`
and re-exports all helpers from `ember-cli-page-object` except `getter`.