### PR TITLE
Always deep clone objects in deepMergeDescriptors

### DIFF
--- a/addon-test-support/-private/utils/deep-merge-descriptors.js
+++ b/addon-test-support/-private/utils/deep-merge-descriptors.js
@@ -16,14 +16,14 @@ export default function deepMergeDescriptors(dest, src) {
       if (isObject(destValue) && isObject(srcValue)) {
         descriptor.value = deepMergeDescriptors(destValue, srcValue);
 
-      // Defer to the dest value otherwise
+      // Defer to the 'dest' value otherwise (ie, do not redefine property)
       } else {
         return;
       }
 
-    // The property only exists on the src
-    } else {
-      descriptor.value = isObject(srcValue) ? deepMergeDescriptors({}, srcValue) : srcValue;
+    // The property only exists on 'src'
+    } else if (isObject(srcValue)) {
+      descriptor.value = deepMergeDescriptors({}, srcValue);
     }
 
     Object.defineProperty(dest, name, descriptor);

--- a/addon-test-support/-private/utils/deep-merge-descriptors.js
+++ b/addon-test-support/-private/utils/deep-merge-descriptors.js
@@ -1,23 +1,29 @@
+function isObject(obj) {
+  return typeof obj === 'object' && obj !== null;
+}
+
 export default function deepMergeDescriptors(dest, src) {
   Object.getOwnPropertyNames(src).forEach((name) => {
     // Copy descriptor
-    let descriptor = Object.getOwnPropertyDescriptor(src, name)
+    let descriptor = Object.getOwnPropertyDescriptor(src, name);
+    const { value: srcValue } = descriptor;
 
-    if (Object.hasOwnProperty.call(dest, name)) {
-      const { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
-      const { value: srcValue } = descriptor;
+    if (isObject(srcValue)) {
+      let mergeTarget = {};
 
-      if (
-        typeof destValue === 'object' && destValue !== null
-        && typeof srcValue === 'object' && srcValue !== null
-      ) {
-        descriptor.value = deepMergeDescriptors(destValue, srcValue);
-      } else {
-        return;
+      if (Object.hasOwnProperty.call(dest, name)) {
+        let { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
+
+        mergeTarget = isObject(destValue) ? destValue : mergeTarget;
       }
+
+      descriptor.value = deepMergeDescriptors(mergeTarget, srcValue);
+
+    } else if (Object.hasOwnProperty.call(dest, name)) {
+      return;
     }
 
-    Object.defineProperty(dest, name, descriptor)
+    Object.defineProperty(dest, name, descriptor);
   });
 
   return dest;

--- a/addon-test-support/-private/utils/deep-merge-descriptors.js
+++ b/addon-test-support/-private/utils/deep-merge-descriptors.js
@@ -8,19 +8,22 @@ export default function deepMergeDescriptors(dest, src) {
     let descriptor = Object.getOwnPropertyDescriptor(src, name);
     const { value: srcValue } = descriptor;
 
-    if (isObject(srcValue)) {
-      let mergeTarget = {};
+    // The property exists on both objects
+    if (Object.hasOwnProperty.call(dest, name)) {
+      let { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
 
-      if (Object.hasOwnProperty.call(dest, name)) {
-        let { value: destValue } = Object.getOwnPropertyDescriptor(dest, name);
+      // Deep merge if both are objects
+      if (isObject(destValue) && isObject(srcValue)) {
+        descriptor.value = deepMergeDescriptors(destValue, srcValue);
 
-        mergeTarget = isObject(destValue) ? destValue : mergeTarget;
+      // Defer to the dest value otherwise
+      } else {
+        return;
       }
 
-      descriptor.value = deepMergeDescriptors(mergeTarget, srcValue);
-
-    } else if (Object.hasOwnProperty.call(dest, name)) {
-      return;
+    // The property only exists on the src
+    } else {
+      descriptor.value = isObject(srcValue) ? deepMergeDescriptors({}, srcValue) : srcValue;
     }
 
     Object.defineProperty(dest, name, descriptor);


### PR DESCRIPTION
Previously, the behavior of `deepMergeDescriptors` was such that a given object property descriptor would only be deep merged if both the destination and source property values were `typeof` 'object'.  In the case that `typeof srcValue === 'object'` but the property did not exist on the destination (`!Object.hasOwnProperty.call(dest, name)`), we would define the property on the destination object using the same descriptor from the source. Therefore, the references to `value` in both objects would be shared.

This changeset ensures that we deep merge in all cases where the source property value is an object so that we do not share objects (ie, we now deep clone).