### PR TITLE
Pass parent node for collection in get instead of setup

### DIFF
--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -59,29 +59,32 @@ class CollectionProxy {
 }
 
 export function collection(definition) {
-  let collectionProxy;
+  let collectionProxy,
+      collectionKey,
+      pageDefinition = {};
 
   return {
     isDescriptor: true,
 
     setup(node, key) {
+      collectionKey = key;
+
       const {
         scope: itemScope,
         resetScope
       } = this._definition;
-
-      let pageDefinition = {};
 
       pageDefinition[key] = pageObjectCollection({
         itemScope,
         resetScope,
         item: this._definition
       });
-
-      collectionProxy = new CollectionProxy(create(pageDefinition, { parent: node }), key);
     },
 
     get() {
+      if (!collectionProxy) {
+        collectionProxy = new CollectionProxy(create(pageDefinition, { parent: this }), collectionKey)
+      }
       return collectionProxy;
     },
 


### PR DESCRIPTION
Previously, we were creating the collection page object in the `setup` function. This was a departure from the parent `ember-cli-page-object`, in which the page object doesn't actually get created until `get` is called. This somehow resulted in the parent node for all instances of a certain type of PageObject being set to the same node whenever a new instance was setup. Frankly, I don't fully understand why this behavior was happening, but changing the behavior to set the parent using `this` in the `get` of the descriptor resolves the bug while also maintaining the correct tree hierarchy (through `__parentTreeNode`) for all nodes. I initially had fixed the bug by just removing the options param with `{ parent: node }`, but that resulted in "orphan" nodes with no parents, whereas this fix circumvents that problem.

@pzuraq would love to go over this in more detail with you