### PR TITLE
bugfix(collection): Prevent instances from sharing collection proxy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
   },
   extends: 'eslint:recommended',
   env: {
-    browser: true
+    browser: true,
+    es6: true
   },
   rules: {
   }

--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -59,7 +59,10 @@ class CollectionProxy {
 }
 
 export function collection(definition) {
-  let collectionProxy;
+  // Collection proxies need to be created for each of instances of this collection,
+  // and there may be many since page objects can be reused in many locations. We use
+  // a WeakMap to store each instance relative to its node.
+  let collectionProxyMap = new WeakMap();
 
   return {
     isDescriptor: true,
@@ -78,11 +81,13 @@ export function collection(definition) {
         item: this._definition
       });
 
-      collectionProxy = new CollectionProxy(create(pageDefinition, { parent: node }), key);
+      let collectionProxy = new CollectionProxy(create(pageDefinition, { parent: node }), key);
+
+      collectionProxyMap.set(node, collectionProxy);
     },
 
     get() {
-      return collectionProxy;
+      return collectionProxyMap.get(this);
     },
 
     _definition: definition

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -14,10 +14,9 @@ const SimpleListPage = PageObject.extend({
   })
 });
 
-
 moduleForAcceptance('Acceptance | collection');
 
-test('visiting /', function(assert) {
+test('collection works as expected', function(assert) {
   const list = SimpleListPage.create();
 
   visit('/');
@@ -40,5 +39,24 @@ test('visiting /', function(assert) {
     assert.equal(list.items.findOne({ text: 'Foo', isActive: true }), undefined);
 
     assert.throws(() => list.items.findOne((i) => i.isActive || i.text === 'Foo'), /Expected at most one result from findOne query, but found 2/);
+  });
+});
+
+test('collections do not share instances of proxies', function(assert) {
+  let page = PageObject.extend({
+    scope: 'foo-bar-baz',
+
+    simpleList: SimpleListPage
+  }).create();
+
+  // create a simple list to side-effect
+  SimpleListPage.create();
+
+  visit('/');
+
+  andThen(() => {
+    assert.throws(() => {
+      assert.equal(page.simpleList.items.eq(0).text, 'Foo')
+    }, /foo-bar-baz \[data-test-simple-list\] \[data-test-simple-list-item\]:eq\(0\)/);
   });
 });


### PR DESCRIPTION
Collection instances were sharing their proxy as a single closure
variable that each instance had access to, and the last instance would
overwrite. This PR adds a WeakMap to track collections per-instance
instead, preventing this issue. The map is still created per-collection
property, so there is no chance of overlap. This may be suboptimal and
in the future we should try to make it better (extended collections will
create an unused collection map, for instance) but should be fine for
now.

Supercedes #7, cc @billylittlefield 