### PR TITLE
refactor(create): Clone definitions instead of mutating them

### DIFF
--- a/addon-test-support/-private/utils/clone.js
+++ b/addon-test-support/-private/utils/clone.js
@@ -1,19 +1,21 @@
-export default function walk(object, ...cbs) {
+export default function cloneWalk(object, ...cbs) {
+  let clone = {};
+
   Object.getOwnPropertyNames(object).forEach((name) => {
     // Extract descriptors so we don't trigger getters or setters
     let descriptor = Object.getOwnPropertyDescriptor(object, name);
 
     for (let i = 0; i < cbs.length; i++) {
-      cbs[i](object, name, descriptor);
+      // run functions over the descriptor to update it if they want to
+      cbs[i](name, descriptor);
     }
-
-    // Get the descriptor again, since it could have been modified
-    descriptor = Object.getOwnPropertyDescriptor(object, name);
 
     if (typeof descriptor.value === 'object' && descriptor.value !== null) {
-      walk(descriptor.value, ...cbs);
+      descriptor.value = cloneWalk(descriptor.value, ...cbs);
     }
+
+    Object.defineProperty(clone, name, descriptor);
   });
 
-  return object;
+  return clone;
 }

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -5,26 +5,19 @@ import { module, test } from 'ember-qunit';
 module('basic tests');
 
 test('it properly converts descriptors', function(assert) {
-  assert.expect(3);
+  assert.expect(1);
 
   let page = PageObject.extend({
     get foo() {
       assert.ok(true, 'getter converted correctly');
-    },
-
-    set foo(value) {
-      assert.ok(true, 'setter converted correctly');
     }
-  });
+  }).create();
 
-  assert.ok(page.definition.foo.isDescriptor, 'function marked as descriptor correctly')
-
-  page.definition.foo.get();
-  page.definition.foo.set();
+  page.foo;
 });
 
 test('it properly merges subcontexts', function(assert) {
-  assert.expect(4);
+  assert.expect(3);
 
   let page = PageObject.extend({
     foo: 123,
@@ -37,14 +30,12 @@ test('it properly merges subcontexts', function(assert) {
         assert.ok(true, 'nested function merged correctly')
       }
     }
-  });
+  }).create();
 
-  assert.equal(page.definition.foo, 123);
-  assert.equal(page.definition.content.bar, 456);
+  assert.equal(page.foo, 123);
+  assert.equal(page.content.bar, 456);
 
-  assert.ok(page.definition.content.baz, 'nested function marked as descriptor correctly')
-
-  page.definition.content.baz.get();
+  page.content.baz;
 });
 
 test('it adds scope with scope shortcut helper', function(assert) {


### PR DESCRIPTION
This refactors us to fully clone definitions when `create`ing, instead of mutating them in some cases. Mutating could result in changes to nested page objects that are used elsewhere, so we should do this to maintain safety.