### PR TITLE
bugfix(collection): Always extract getters

### DIFF
--- a/addon-test-support/-private/page-object.js
+++ b/addon-test-support/-private/page-object.js
@@ -4,6 +4,7 @@ import { useNativeEvents } from 'ember-cli-page-object/extend';
 
 import create from './utils/create';
 import deepMergeDescriptors from './utils/deep-merge-descriptors';
+import extractGetters from './utils/extract-getters';
 
 // pre-emptively turn on native events since we'll need them
 useNativeEvents();
@@ -17,7 +18,11 @@ export class PageObject {
   extend(extension) {
     assert('must provide a definition with atleast one key when extending a PageObject', extension && Object.keys(extension).length > 0);
 
-    return new PageObject(deepMergeDescriptors(extension, this.definition))
+    let finalizedDefinition = deepMergeDescriptors(
+      extractGetters(extension), this.definition
+    );
+
+    return new PageObject(finalizedDefinition);
   }
 
   scope(scope) {

--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -5,6 +5,7 @@ import { count } from 'ember-cli-page-object';
 import { buildSelector } from 'ember-cli-page-object/extend';
 
 import create from '../utils/create';
+import extractGetters from '../utils/extract-getters';
 
 class CollectionProxy {
   constructor(definition, parent, key) {
@@ -22,7 +23,9 @@ class CollectionProxy {
       let { definition, parent, key } = this;
       let scope = buildSelector({}, definition.scope, { at: index });
 
-      let finalizedDefinition = Object.assign(Object.assign({}, definition), { scope });
+      let finalizedDefinition = extractGetters(definition);
+
+      finalizedDefinition.scope = scope;
 
       let tree = create(finalizedDefinition, { parent });
 

--- a/addon-test-support/-private/utils/extract-getters.js
+++ b/addon-test-support/-private/utils/extract-getters.js
@@ -1,0 +1,22 @@
+import { getter } from 'ember-cli-page-object/macros';
+
+export default function extractGetters(definition) {
+  let finalizedDefinition = {};
+
+  // Clone the original definition one layer deep so we don't modify scope on it
+  Object.getOwnPropertyNames(definition).forEach((name) => {
+    let descriptor = Object.getOwnPropertyDescriptor(definition, name);
+
+    if (typeof descriptor.get === 'function') {
+      descriptor.value = getter(descriptor.get);
+
+      descriptor.writable = true;
+      delete descriptor.get;
+      delete descriptor.set;
+    }
+
+    Object.defineProperty(finalizedDefinition, name, descriptor);
+  });
+
+  return finalizedDefinition;
+}

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -16,6 +16,16 @@ test('it properly converts descriptors', function(assert) {
   assert.equal(page.foo, 'bar', 'getter converted correctly');
 });
 
+test('descriptors are not called prematurely', function(assert) {
+  assert.expect(0);
+
+  PageObject.extend({
+    get foo() {
+      assert.ok(false, 'getter called prematurely');
+    }
+  }).create();
+});
+
 test('it properly merges subcontexts', function(assert) {
   assert.expect(3);
 

--- a/tests/unit/properties-test.js
+++ b/tests/unit/properties-test.js
@@ -23,3 +23,26 @@ test('it properly merges collections', function(assert) {
   assert.equal(page.definition.content._definition.bar, 456);
   assert.equal(page.definition.content._definition.baz, 789);
 });
+
+test('getters can be used in collection definitions', function(assert) {
+  assert.expect(1);
+
+  let page = PageObject.extend({
+    foo: 123,
+    content: collection({
+      get foo() {
+        assert.ok(false, 'getter called prematurely')
+      }
+    })
+  }).extend({
+    foo: 456,
+    content: collection({
+      get bar() {
+        return 123;
+      }
+    })
+  }).create();
+
+  page.content.eq(0);
+  assert.equal(page.content.eq(0).bar, 123, 'getter gets merged correctly');
+});


### PR DESCRIPTION
Definitions have to go through many layers of cloning and assignment
in ec-page-object. Unfortunately this will trigger getters early in some
cases. This PR always extracts getters for the first level so they can't
be triggered early.