### PR TITLE
Redefine definition in collection constructor

### DIFF
--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -10,6 +10,10 @@ import extractGetters from '../utils/extract-getters';
 class CollectionProxy {
   constructor(definition, parent, key) {
     this.definition = definition;
+    if (this.definition.definition !== undefined) {
+      // This is the case when definition is a PageObject itself
+      this.definition = this.definition.definition;
+    }
     this.parent = parent;
     this.key = key;
 
@@ -24,11 +28,6 @@ class CollectionProxy {
       let scope = buildSelector({}, definition.scope, { at: index });
 
       let finalizedDefinition = extractGetters(definition);
-      // This is the case when definition is a PageObject itself
-      if (finalizedDefinition.definition !== undefined) {
-        finalizedDefinition = finalizedDefinition.definition;
-      }
-
       finalizedDefinition.scope = scope;
 
       let tree = create(finalizedDefinition, { parent });

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -64,11 +64,7 @@ test('collections do not share instances of proxies', function(assert) {
 
 test('Collection works with PageObject definition', function(assert) {
   let Foo = PageObject.extend({
-    scope: 'foo-page-object',
-
-    name() {
-      return 'This is Foo class';
-    }
+    scope: 'foo-page-object'
   });
   let bar = PageObject.extend({
     scope: '[data-test-simple-list-wrapper]',
@@ -82,7 +78,10 @@ test('Collection works with PageObject definition', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.equal(bar.list.foos.eq(0).isPresent, true,
-      'Collection works with Page Object definition');
+    assert.equal(
+      bar.list.foos.eq(0).isPresent,
+      true,
+      'Collection works with Page Object definition'
+    );
   });
 });

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -71,13 +71,18 @@ test('Collection works with PageObject definition', function(assert) {
     }
   });
   let bar = PageObject.extend({
-    foos: collection(Foo.scope('[data-test-simple-list-item]'))
+    scope: '[data-test-simple-list-wrapper]',
+
+    list: {
+      scope: '[data-test-simple-list]',
+      foos: collection(Foo.scope('[data-test-simple-list-item]'))
+    }
   }).create();
 
   visit('/');
 
   andThen(() => {
-    assert.equal(bar.foos.eq(0).name(), 'This is Foo class',
+    assert.equal(bar.list.foos.eq(0).isPresent, true,
       'Collection works with Page Object definition');
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
 {{double-toggle-button}}
 
-{{simple-list}}
+{{simple-list data-test-simple-list-wrapper=true}}


### PR DESCRIPTION
The PR https://github.com/pzuraq/ember-classy-page-object/pull/13 fixes an issue when collection definition is a PageObject. However, it does not completely fix all problems as the `definition` of collection is still a PageObject and hence `definition.scope` is defined incorrectly. 

This PR fixes that redefining `this.definition` in the constructor if it detects if it's a PageObject.