### PR TITLE
Make sure `findOne` throws if no elements are found

### DIFF
--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -53,7 +53,7 @@ class CollectionProxy {
   findOne(query) {
     let result = this.findAll(query);
 
-    assert(`Expected at most one result from findOne query, but found ${result.length}`, result.length <= 1);
+    assert(`Expected at most one result from 'findOne' query in '${this._collection.key}' collection, but found ${result.length}`, result.length === 1);
 
     return result[0];
   }

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -37,9 +37,9 @@ test('collection works as expected', function(assert) {
 
     assert.equal(list.items.findOne((i) => i.isActive).text, 'Bar');
     assert.equal(list.items.findOne({ text: 'Bar', isActive: true }).text, 'Bar');
-    assert.equal(list.items.findOne({ text: 'Foo', isActive: true }), undefined);
+    assert.throws(() => assert.equal(list.items.findOne({ text: 'Foo', isActive: true }), /Expected at most one result from 'findOne' query in 'foos' collection, but found 0/));
 
-    assert.throws(() => list.items.findOne((i) => i.isActive || i.text === 'Foo'), /Expected at most one result from findOne query, but found 2/);
+    assert.throws(() => list.items.findOne((i) => i.isActive || i.text === 'Foo'), /Expected at most one result from 'findOne' query in 'items' collection, but found 2/);
   });
 });
 
@@ -61,7 +61,6 @@ test('collections do not share instances of proxies', function(assert) {
     }, /foo-bar-baz \[data-test-simple-list\] \[data-test-simple-list-item\]:eq\(0\)/);
   });
 });
-
 
 test('Collection works with PageObject definition', function(assert) {
   let bar = new PageObject({


### PR DESCRIPTION
If you have the following code:

```javascript
// in this case, `findOne` couldn't find any elements with `displayName: 'some name'`
PAGE.elements.findOne({ displayName: 'some name' }).anotherElement.click()
```

it throws with not very helpful message: `Cannot read property 'anotherElement' of undefined`.

This change adds a more helpful error: `Expected at most one result from 'findOne' query in 'elements' collection`.

cc @NicholasMohr