### PR TITLE
Include `Ember.inspect(query)` in failed assertion for `findOne`

### DIFF
--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -1,7 +1,5 @@
-import Ceibo from 'ceibo';
-
-import { assert } from '@ember/debug';
 import { create, collection as ecpoCollection } from 'ember-cli-page-object';
+import { assert, inspect } from '@ember/debug';
 
 class CollectionProxy {
   constructor(scope, definition, key, parent) {
@@ -53,7 +51,12 @@ class CollectionProxy {
   findOne(query) {
     let result = this.findAll(query);
 
-    assert(`Expected at most one result from 'findOne' query in '${this._collection.key}' collection, but found ${result.length}`, result.length === 1);
+    assert(
+      `Expected at most one result from 'findOne' query in '${
+        this._collection.key
+      }' collection, but found ${result.length} using query ${inspect(query)}`,
+      result.length === 1
+    );
 
     return result[0];
   }
@@ -62,7 +65,7 @@ class CollectionProxy {
     let predicate;
 
     if (typeof query === 'object') {
-      predicate = (item) => {
+      predicate = item => {
         let isMatch = true;
 
         for (let key in query) {
@@ -70,11 +73,16 @@ class CollectionProxy {
         }
 
         return isMatch;
-      }
+      };
     } else if (typeof query === 'function') {
       predicate = query;
     } else {
-      assert(`Expected query for findAll to be either an object or function, received: ${query}`, false);
+      assert(
+        `Expected query for findAll to be either an object or function, received: ${inspect(
+          query
+        )}`,
+        false
+      );
     }
 
     return this.filter(predicate);

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -2,7 +2,6 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
 import PageObject, { collection, hasClass, text } from 'ember-classy-page-object';
-// import { findElement } from 'ember-classy-page-object/extend';
 
 const SimpleListPage = PageObject.extend({
   scope: '[data-test-simple-list]',
@@ -37,9 +36,8 @@ test('collection works as expected', function(assert) {
 
     assert.equal(list.items.findOne((i) => i.isActive).text, 'Bar');
     assert.equal(list.items.findOne({ text: 'Bar', isActive: true }).text, 'Bar');
-    assert.throws(() => assert.equal(list.items.findOne({ text: 'Foo', isActive: true }), /Expected at most one result from 'findOne' query in 'foos' collection, but found 0/));
-
-    assert.throws(() => list.items.findOne((i) => i.isActive || i.text === 'Foo'), /Expected at most one result from 'findOne' query in 'items' collection, but found 2/);
+    assert.throws(() => list.items.findOne({ text: 'Foo', isActive: true }), /Expected at most one result.*'findOne' query in 'items' collection.*but found 0.*using query.*isActive: true/);
+    assert.throws(() => list.items.findOne((i) => i.isActive || i.text === 'Foo'), /Expected at most one result.*'findOne' query in 'items' collection.*but found 2/);
   });
 });
 
@@ -57,7 +55,7 @@ test('collections do not share instances of proxies', function(assert) {
 
   andThen(() => {
     assert.throws(() => {
-      assert.equal(page.simpleList.items.objectAt(0).text, 'Foo')
+      page.simpleList.items.objectAt(0).text
     }, /foo-bar-baz \[data-test-simple-list\] \[data-test-simple-list-item\]:eq\(0\)/);
   });
 });


### PR DESCRIPTION
This makes it a little easier to debug chained property accesses on page objects when an internal `findOne` fails to find anything. This modifies the assertion message to include details about the query that was passed to `findOne`.

Also: Fix 2 tests that had wrong arguments order for `assert.throws()`.